### PR TITLE
Use current year in case the year is omitted in the birthday field

### DIFF
--- a/src/android/ContactAccessorSdk5.java
+++ b/src/android/ContactAccessorSdk5.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.sql.Date;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -1974,7 +1975,11 @@ public class ContactAccessorSdk5 extends ContactAccessor {
 
         try {
             int colBirthday = c.getColumnIndexOrThrow(CommonDataKinds.Event.START_DATE);
-            return Date.valueOf(c.getString(colBirthday));
+            String birthday = c.getString(colBirthday);
+            if(birthday.startsWith("--")){
+                birthday = birthday.replaceFirst("-", String.valueOf(Calendar.getInstance().get(Calendar.YEAR)));
+            }
+            return Date.valueOf(birthday);
         } catch (IllegalArgumentException e) {
             LOG.e(LOG_TAG, "Failed to get birthday for contact from cursor", e);
             return null;


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
- Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#213


### Description
<!-- Describe your changes in detail -->
In case the year is omitted in the birthday field of the contact it will use the current year in order to parse a valid Date.


### Testing
<!-- Please describe in detail how you tested your changes. -->
Tested different contacts having birthday with year, birthday with year omitted and contact without birthday.


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
